### PR TITLE
Quote all env vars (secrets) values

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ function main() {
     fi
     if [[ ! -z $( cat $update ) ]] ; then
       echo "Uploading new environment variables."
-      aws --profile herokles ssm put-parameter --type String --name /${PROJECT}/${ENV} --overwrite --value "$( jq -s . $json )"
+      aws --profile herokles ssm put-parameter --type String --name /${PROJECT}/${ENV} --overwrite --value "$( jq -S . $json )"
     fi
   else
     if [[ ! -z $( jq -r '.InvalidParameters | .[]' $json_full ) ]] ; then

--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ function main() {
     fi
     if [[ ! -z $( cat $update ) ]] ; then
       echo "Uploading new environment variables."
-      aws --profile herokles ssm put-parameter --type String --name /${PROJECT}/${ENV} --overwrite --value "$( jq -c . $json )"
+      aws --profile herokles ssm put-parameter --type String --name /${PROJECT}/${ENV} --overwrite --value "$( jq -s . $json )"
     fi
   else
     if [[ ! -z $( jq -r '.InvalidParameters | .[]' $json_full ) ]] ; then

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ function main() {
   }
   local key val
   for key in $( echo "$json" | jq -r 'keys[]' ) ; do
-    val=$( echo "$json" | jq -r .$key )
+    val=$( echo "$json" | jq .$key )
     if [[ $val == true ]] || [[ $val == false ]] || [[ $val =~ ^[0-9]+$ ]] ; then
       val=\"$val\"
     fi


### PR DESCRIPTION
https://helm.sh/docs/chart_best_practices/values/#make-types-clear

Fixes issues with int-like env var values like `SALESFORCE_API_VERSION=60.0"`, which helm would turn into `60`. Could be worked around with json escaped quoting ( `"SALESFORCE_API_VERSION": "\"60.0\""` ), but that only works on one level (can't really inherit these vars from one AWS Parameter Store to another) and adding more escapes seems anti-pattern. Using explicit string type for all secrets (env vars) seems like a better solution.